### PR TITLE
Add support for hierarchical keys

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: KinD (Kubernetes in Docker) Action
-      uses: engineerd/setup-kind@v0.2.0
+      uses: engineerd/setup-kind@v0.5.0
     - name: Install configmap and secret
       run: |
         kubectl create configmap test-config --from-literal=testkey=testvalue

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,8 +13,8 @@ jobs:
       uses: engineerd/setup-kind@v0.5.0
     - name: Install configmap and secret
       run: |
-        kubectl create configmap test-config --from-literal=testkey=testvalue
-        kubectl create secret generic test-secret --from-literal=testsecretkey=testsecretvalue  
+        kubectl create configmap test-config --from-literal=Test__Config=testvalue
+        kubectl create secret generic test-secret --from-literal=Test__Secret=testsecretvalue  
         kubectl label configmap test-config app=testapp
         kubectl label secret test-secret app=testapp  
     - name: Run integrationtest

--- a/Configmap.Extensions.Test/IntegrationTests.cs
+++ b/Configmap.Extensions.Test/IntegrationTests.cs
@@ -18,8 +18,8 @@ namespace Kubernetes.Configuration.Extensions.Test
 
             var config = builder.Build();
             Assert.NotEmpty(config.Providers);
-            Assert.Equal("testvalue", config.GetChildren().First().Value);
-            Assert.Equal("testsecretvalue", config.GetChildren().Last().Value);
+            Assert.Equal("testvalue", config.AsEnumerable().Single(x => x.Key == "Test:Config").Value);
+            Assert.Equal("testsecretvalue", config.AsEnumerable().Single(x => x.Key == "Test:Secret").Value);
         }
     }
 }

--- a/Kubernetes.Config/Configmap/ConfigmapConfigurationExtensions.cs
+++ b/Kubernetes.Config/Configmap/ConfigmapConfigurationExtensions.cs
@@ -5,7 +5,7 @@ namespace Kubernetes.Configuration.Extensions.Configmap
 {
     public static class ConfigmapConfigurationExtensions
     {   
-        public static IConfigurationBuilder AddKubernetesConfigmap(this IConfigurationBuilder builder, string labelSelector, string namespaceSelector = "default", bool reloadOnChange = false)
+        public static IConfigurationBuilder AddKubernetesConfigmap(this IConfigurationBuilder builder, string labelSelector, string namespaceSelector = "default", bool reloadOnChange = false, string separator = "__")
         {
             if (builder == null)
             {

--- a/Kubernetes.Config/Configmap/ConfigmapConfigurationProvider.cs
+++ b/Kubernetes.Config/Configmap/ConfigmapConfigurationProvider.cs
@@ -54,7 +54,7 @@ namespace Kubernetes.Configuration.Extensions.Configmap
                 foreach (var dataItem in dataList)
                 {
                     foreach (var (key, value) in dataItem)
-                        Data.Add(key.Replace(_separator, ":"), value);
+                        Data[key.Replace(_separator, ":")] = value;
                 }
             }
             catch

--- a/Kubernetes.Config/Configmap/ConfigmapConfigurationProvider.cs
+++ b/Kubernetes.Config/Configmap/ConfigmapConfigurationProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using k8s;
@@ -11,13 +11,15 @@ namespace Kubernetes.Configuration.Extensions.Configmap
     {
         private readonly string _namespaceSelector;
         private readonly string _labelSelector;
+        private readonly string _separator;
         private readonly k8s.Kubernetes _client;
-        public ConfigmapConfigurationProvider() : this(string.Empty, string.Empty, false)
+        public ConfigmapConfigurationProvider() : this(string.Empty, string.Empty, "__", false)
         { }
-        public ConfigmapConfigurationProvider(string? namespaceSelector, string? labelSelector, bool reloadOnChange)
+        public ConfigmapConfigurationProvider(string? namespaceSelector, string? labelSelector, string? separator, bool reloadOnChange)
         {
             _namespaceSelector = namespaceSelector ?? string.Empty;
             _labelSelector = labelSelector ?? string.Empty;
+            _separator = separator ?? "__";
             KubernetesClientConfiguration config;
             try
             {
@@ -51,8 +53,8 @@ namespace Kubernetes.Configuration.Extensions.Configmap
                 var dataList = configMaps.Items.Where(w => w.Data != null).Select(s => s.Data);
                 foreach (var dataItem in dataList)
                 {
-                    foreach (var item in dataItem)
-                        Data.Add(item.Key, item.Value);
+                    foreach (var (key, value) in dataItem)
+                        Data.Add(key.Replace(_separator, ":"), value);
                 }
             }
             catch

--- a/Kubernetes.Config/Configmap/ConfigmapConfigurationSource.cs
+++ b/Kubernetes.Config/Configmap/ConfigmapConfigurationSource.cs
@@ -6,10 +6,11 @@ namespace Kubernetes.Configuration.Extensions.Configmap
     {
         public string? Namespace { get; set; }
         public string? LabelSelector { get; set; }
+        public string? Separator { get; set; }
         public bool ReloadOnChange { get; set; }
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new ConfigmapConfigurationProvider(Namespace, LabelSelector, ReloadOnChange);
+            return new ConfigmapConfigurationProvider(Namespace, LabelSelector, Separator, ReloadOnChange);
         }
     }
 }

--- a/Kubernetes.Config/Kubernetes.Configuration.Extensions.csproj
+++ b/Kubernetes.Config/Kubernetes.Configuration.Extensions.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
-    <Version>1.1.0</Version>
-    <AssemblyVersion>0.1.1.0</AssemblyVersion>
-    <FileVersion>0.1.1.0</FileVersion>
+    <Version>1.2.0</Version>
+    <AssemblyVersion>0.1.2.0</AssemblyVersion>
+    <FileVersion>0.1.2.0</FileVersion>
     <Description>Adds extension methods for reading Kubernetes Configmaps and Secrets</Description>
     <Authors>Tommy Kindmark</Authors>
     <PackageTags>Kubernetes</PackageTags>

--- a/Kubernetes.Config/Secret/SecretConfigurationExtensions.cs
+++ b/Kubernetes.Config/Secret/SecretConfigurationExtensions.cs
@@ -5,7 +5,7 @@ namespace Kubernetes.Configuration.Extensions.Secret
 {
     public static class SecretConfigurationExtensions
     {
-        public static IConfigurationBuilder AddKubernetesSecret(this IConfigurationBuilder builder, string labelSelector, string namespaceSelector = "default", string separator = "__", bool reloadOnChange = false)
+        public static IConfigurationBuilder AddKubernetesSecret(this IConfigurationBuilder builder, string labelSelector, string namespaceSelector = "default", string separator = "__", bool reloadOnChange = false, bool decodeData = true)
         {
             if (builder == null)
             {
@@ -15,7 +15,7 @@ namespace Kubernetes.Configuration.Extensions.Secret
             {
                 throw new ArgumentException("Invalid label selector", nameof(labelSelector));
             }
-            builder.Add(new SecretConfigurationSource { Namespace = namespaceSelector, LabelSelector = labelSelector, Separator = separator, ReloadOnChange = reloadOnChange});
+            builder.Add(new SecretConfigurationSource { Namespace = namespaceSelector, LabelSelector = labelSelector, Separator = separator, ReloadOnChange = reloadOnChange, DecodeData = decodeData});
             return builder;
         }
 

--- a/Kubernetes.Config/Secret/SecretConfigurationExtensions.cs
+++ b/Kubernetes.Config/Secret/SecretConfigurationExtensions.cs
@@ -5,7 +5,7 @@ namespace Kubernetes.Configuration.Extensions.Secret
 {
     public static class SecretConfigurationExtensions
     {
-        public static IConfigurationBuilder AddKubernetesSecret(this IConfigurationBuilder builder, string labelSelector, string namespaceSelector = "default", bool reloadOnChange = false)
+        public static IConfigurationBuilder AddKubernetesSecret(this IConfigurationBuilder builder, string labelSelector, string namespaceSelector = "default", string separator = "__", bool reloadOnChange = false)
         {
             if (builder == null)
             {
@@ -15,7 +15,7 @@ namespace Kubernetes.Configuration.Extensions.Secret
             {
                 throw new ArgumentException("Invalid label selector", nameof(labelSelector));
             }
-            builder.Add(new SecretConfigurationSource { Namespace = namespaceSelector, LabelSelector = labelSelector, ReloadOnChange = reloadOnChange});
+            builder.Add(new SecretConfigurationSource { Namespace = namespaceSelector, LabelSelector = labelSelector, Separator = separator, ReloadOnChange = reloadOnChange});
             return builder;
         }
 

--- a/Kubernetes.Config/Secret/SecretConfigurationProvider.cs
+++ b/Kubernetes.Config/Secret/SecretConfigurationProvider.cs
@@ -59,7 +59,7 @@ namespace Kubernetes.Configuration.Extensions.Secret
                 {
                     foreach (var (key, value) in dataItem)
                     {
-                        Data.Add(key.Replace(_separator, ":"), _decodeData ? DecodeSecret(value) : Encoding.UTF8.GetString(value));
+                        Data[key.Replace(_separator, ":")] = _decodeData ? DecodeSecret(value) : Encoding.UTF8.GetString(value);
                     }
                 }
             }

--- a/Kubernetes.Config/Secret/SecretConfigurationProvider.cs
+++ b/Kubernetes.Config/Secret/SecretConfigurationProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,15 +12,17 @@ namespace Kubernetes.Configuration.Extensions.Secret
     {
         private readonly string _namespaceSelector;
         private readonly string _labelSelector;
+        private readonly string _separator;
         private readonly k8s.Kubernetes _client;
         private readonly bool _decodeData;
 
-        public SecretConfigurationProvider() : this(string.Empty, string.Empty, false)
+        public SecretConfigurationProvider() : this(string.Empty, string.Empty, "__", false)
         { }
-        public SecretConfigurationProvider(string? namespaceSelector, string? labelSelector, bool reloadOnChange, bool decodeData = true)
+        public SecretConfigurationProvider(string? namespaceSelector, string? labelSelector, string? separator, bool reloadOnChange, bool decodeData = true)
         {
             _namespaceSelector = namespaceSelector ?? string.Empty;
             _labelSelector = labelSelector ?? string.Empty;
+            _separator = separator ?? "__";
             _decodeData = decodeData;
             KubernetesClientConfiguration config;
             try
@@ -57,7 +59,7 @@ namespace Kubernetes.Configuration.Extensions.Secret
                 {
                     foreach (var (key, value) in dataItem)
                     {
-                        Data.Add(key, _decodeData ? DecodeSecret(value) : Encoding.UTF8.GetString(value));
+                        Data.Add(key.Replace(_separator, ":"), _decodeData ? DecodeSecret(value) : Encoding.UTF8.GetString(value));
                     }
                 }
             }

--- a/Kubernetes.Config/Secret/SecretConfigurationSource.cs
+++ b/Kubernetes.Config/Secret/SecretConfigurationSource.cs
@@ -8,9 +8,10 @@ namespace Kubernetes.Configuration.Extensions.Secret
         public string? LabelSelector { get; set; }
         public string? Separator { get; set; }
         public bool ReloadOnChange { get; set; }
+        public bool DecodeData { get; set; } = true;
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         { 
-            return new SecretConfigurationProvider(Namespace, LabelSelector, Separator, ReloadOnChange);
+            return new SecretConfigurationProvider(Namespace, LabelSelector, Separator, ReloadOnChange, DecodeData);
         }
     }
 }

--- a/Kubernetes.Config/Secret/SecretConfigurationSource.cs
+++ b/Kubernetes.Config/Secret/SecretConfigurationSource.cs
@@ -6,10 +6,11 @@ namespace Kubernetes.Configuration.Extensions.Secret
     {
         public string? Namespace { get; set; }
         public string? LabelSelector { get; set; }
+        public string? Separator { get; set; }
         public bool ReloadOnChange { get; set; }
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         { 
-            return new SecretConfigurationProvider(Namespace, LabelSelector, ReloadOnChange);
+            return new SecretConfigurationProvider(Namespace, LabelSelector, Separator, ReloadOnChange);
         }
     }
 }


### PR DESCRIPTION
The ASP.NET Core Configuration API uses a colon (`:`) as separator for hierarchical keys.

Since a colon isn't allowed in a `ConfigMap` or `Secret` key I changed both the `ConfigmapConfigurationProvider` as well as the `SecretConfigurationProvider` to replace a configurable separator with a colon.  
The default separator is `__` in accordance with the built-in `EnvironmentVariablesConfigurationProvider`. (see [Configuration in ASP.NET Core, Environment variables](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-5.0#environment-variables)

Also, I changed the providers to build their dictionaries using `Data[key] = value` rather than `Data.Add(key, value)`.  
If you happen to have multiple secrets/config maps with the same key (e.g. by having multiple TLS secrets) you encountered an `ArgumentException` causing all remaining values to be lost.  
In my opinion, having duplicated keys overridden is less unexpected than some keys missing.